### PR TITLE
MAINT: move the `conda develop .` in the Gitpod config (#13679)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,12 +14,13 @@ tasks:
     prebuild: |
       conda activate scipydev
       python setup.py build_ext --inplace
-      conda develop .
       git submodule update --init
       cd doc 
       make html-scipyorg
       pip install sphinx-autobuild
-    command: conda activate scipydev
+    command: |
+      conda activate scipydev
+      conda develop .
   - name: Develop here
     init: mkdir -p /workspace/scipy/.theia &&  cp /workspace/scipy/tools/docker_dev/settings.json /workspace/scipy/.theia/settings.json
     command: conda activate scipydev


### PR DESCRIPTION
This command writes a conda.pth file to
  /opt/conda/envs/scipydev/lib/python3.8/site-packages/
and that directory is outside of /workspace so doesn't get saved.

The "command" gets executed on every workspace start and restart,
so puts the file in the correct place at the right time.
Before, `cd doc && make html` would fail in a fresh workspace,
this will make it work.

xref gh-13677

[ci skip]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->