### PR TITLE
DOC: correct Voronoi docstring (#13735)

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2497,7 +2497,7 @@ class Voronoi(_QhullUser):
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndim)
-        Coordinates of points to construct a convex hull from
+        Coordinates of points to construct a Voronoi diagram from
     furthest_site : bool, optional
         Whether to compute a furthest-site Voronoi diagram. Default: False
     incremental : bool, optional


### PR DESCRIPTION
* the `Voronoi` class docstring refers to the construction
of the incorrect type of geometric diagram--likely a copy-paste
error from the `ConvexHull` docstring above

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->