### PR TITLE
BUG: io/matlab: preserve dimensions of empty >=2D arrays (#13373)

### DIFF
--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -294,11 +294,11 @@ def matdims(arr, oned_as='column'):
     """
     shape = arr.shape
     if shape == ():  # scalar
-        return (1,1)
-    if functools.reduce(operator.mul, shape) == 0:  # zero elememts
-        return (0,) * np.max([arr.ndim, 2])
+        return (1, 1)
     if len(shape) == 1:  # 1D
-        if oned_as == 'column':
+        if shape[0] == 0:
+            return (0, 0)
+        elif oned_as == 'column':
             return shape + (1,)
         elif oned_as == 'row':
             return (1,) + shape

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -948,6 +948,13 @@ def test_logical_out_type():
     assert_equal(var.dtype.type, np.uint8)
 
 
+def test_roundtrip_zero_dimensions():
+    stream = BytesIO()
+    savemat(stream, {'d':np.empty((10, 0))})
+    d = loadmat(stream)
+    assert d['d'].shape == (10, 0)
+
+
 def test_mat4_3d():
     # test behavior when writing 3-D arrays to matlab 4 files
     stream = BytesIO()

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -19,8 +19,9 @@ def test_matdims():
     # 3d array, rowish vector
     assert_equal(matdims(np.array([[[2,3]]])), (1, 1, 2))
     assert_equal(matdims(np.array([])), (0, 0))  # empty 1-D array
-    assert_equal(matdims(np.array([[]])), (0, 0))  # empty 2-D array
-    assert_equal(matdims(np.array([[[]]])), (0, 0, 0))  # empty 3-D array
+    assert_equal(matdims(np.array([[]])), (1, 0))  # empty 2-D array
+    assert_equal(matdims(np.array([[[]]])), (1, 1, 0))  # empty 3-D array
+    assert_equal(matdims(np.empty((1, 0, 1))), (1, 0, 1))  # empty 3-D array
     # Optional argument flips 1-D shape behavior.
     assert_equal(matdims(np.array([1,2]), 'row'), (1, 2))  # 1-D array, 2 elements
     # The argument has to make sense though


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->